### PR TITLE
Allow query parameters in URL (don't support $ in them though).

### DIFF
--- a/lib/batch.js
+++ b/lib/batch.js
@@ -19,7 +19,7 @@ module.exports.config = function (pack) {
             };
 
             var requests = [];
-            var requestRegex = /(?:\/)(?:\$(\d)+\.)?([\w:\.]*)/g;       // /project/$1.project/tasks, does not allow using array responses
+            var requestRegex = /(?:\/)(?:\$(\d)+\.)?([\w:\.\?=&]*)/g;       // /project/$1.project/tasks, does not allow using array responses
 
             // Validate requests
 


### PR DESCRIPTION
This is a quick fix to allow query parameters in URLs. This might fix Issue #4.
