### PR TITLE
Some characters are not authorized in URLs while they should be.

### DIFF
--- a/lib/batch.js
+++ b/lib/batch.js
@@ -19,7 +19,7 @@ module.exports.config = function (pack) {
             };
 
             var requests = [];
-            var requestRegex = /(?:\/)(?:\$(\d)+\.)?([\w:\.\?=&]*)/g;       // /project/$1.project/tasks, does not allow using array responses
+            var requestRegex = /(?:\/)(?:\$(\d)+\.)?([^\/\$]*)/g;       // /project/$1.project/tasks, does not allow using array responses
 
             // Validate requests
 

--- a/test/batch.js
+++ b/test/batch.js
@@ -25,9 +25,10 @@ describe('Batch', function () {
     var server = null;
 
     var profileHandler = function (request) {
+        var id = request.query.id || 'fa0dbda9b1b';
 
         request.reply({
-            'id': 'fa0dbda9b1b',
+            'id': id,
             'name': 'John Doe'
         });
     };
@@ -166,6 +167,26 @@ describe('Batch', function () {
 
             expect(res[0].id).to.equal('fa0dbda9b1b');
             expect(res[0].name).to.equal('John Doe');
+            expect(res.length).to.equal(1);
+            done();
+        });
+    });
+
+    it('supports query string in the request', function (done) {
+        makeRequest('{ "requests": [{ "method": "get", "path": "/profile?id=someid" }] }', function (res) {
+
+            expect(res[0].id).to.equal('someid');
+            expect(res[0].name).to.equal('John Doe');
+            expect(res.length).to.equal(1);
+            done();
+        });
+    });
+
+    it('supports non alphanum characters in the request', function (done) {
+        makeRequest('{ "requests": [{ "method": "get", "path": "/item/item-_^~&-end" }] }', function (res) {
+
+            expect(res[0].id).to.equal('item-_^~&-end');
+            expect(res[0].name).to.equal('Item');
             expect(res.length).to.equal(1);
             done();
         });


### PR DESCRIPTION
After fixing the querystring issue, I encountered a new one that I didn't expect at first. When using chars such as `-` in the URL, it would also be described as an invalid request.

I patched the regexp once again to make it a lot more generic, hoping it would fix the issue once and for all.

All tests are still green after this change.
