### PR TITLE
Support more versions of Hapi in peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "bassmaster",
   "description": "Batch processing plugin for hapi",
   "repository": "git://github.com/spumko/bassmaster",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "main": "index",
   "keywords": [
     "hapi",


### PR DESCRIPTION
The bump to only support Hapi 5 wasn't really needed. This will restore backwards compatibility.
