### PR TITLE
Allow integer-based reference values in batch, including zero.

### DIFF
--- a/lib/batch.js
+++ b/lib/batch.js
@@ -146,11 +146,11 @@ internals.batch = function (batchRequest, resultsData, pos, parts, callback) {
             var ref = resultsData.resultsMap[parts[i].index];
 
             if (ref) {
-                var value = ref[parts[i].value]||null;
+                var value = ref[parts[i].value];
 
-                if (value) {
+                if (value !== null && value !== undefined) {
 
-                    if (value.match && value.match(/^[\w:]+$/)) {
+                    if (/^[\w:]+$/.test(value)) {
                         path += value;
                     }
                     else {


### PR DESCRIPTION
Includes regression tests for both cases, 100% coverage.

We encountered this error when our returned id was an integer, and batch requests would fail when referencing that id. This allows for integer references and also fixes a case where a zero reference would fail this as well.
