### PR TITLE
Add authentication config options

### DIFF
--- a/lib/batch.js
+++ b/lib/batch.js
@@ -73,6 +73,7 @@ module.exports.config = function (settings) {
             }
         },
         description: settings.description,
+        auth: settings.auth,
         tags: settings.tags
     };
 };

--- a/test/plugin.js
+++ b/test/plugin.js
@@ -53,6 +53,25 @@ describe('bassmaster', function () {
         });
     });
 
+    it('can be given an authentication strategy', function(done){
+
+        var server = new Hapi.Server();
+        var mockScheme = {
+          authenticate: function () {return null;},
+          payload: function() {return null;},
+          response: function() {return null;}
+        };
+        server.auth.scheme('mockScheme', function(){return mockScheme;});
+        server.auth.strategy('mockStrategy','mockScheme');
+        server.pack.register({ plugin: Bassmaster, options: { auth: 'mockStrategy' }}, function (err) {
+
+            expect(err).to.not.exist;
+            var auth = server.table()[0].settings.auth.strategies[0];
+            expect(auth).to.equal('mockStrategy');
+            done();
+        });
+    });
+
     it('can be given custom tags', function(done){
 
         var server = new Hapi.Server();


### PR DESCRIPTION
Here's a PR for issue #35 

The test passes, although I had to infer some stuff about hapi internals, so it's probably pretty brittle.  

I guess I should add my reasoning again. I want to add an `auth: 'token'` parameter to the route object that is associated with the batch route, so I can do authentication stuff at the route level if I want to avoid deferring it to the individual batch endpoints. 
