### PR TITLE
Update license on package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,10 +29,5 @@
   "scripts": {
     "test": "make test-cov"
   },
-  "licenses": [
-    {
-      "type": "BSD",
-      "url": "http://github.com/hapijs/bassmaster/raw/master/LICENSE"
-    }
-  ]
+  "license": "BSD"
 }

--- a/package.json
+++ b/package.json
@@ -29,5 +29,5 @@
   "scripts": {
     "test": "make test-cov"
   },
-  "license": "BSD"
+  "license": "BSD-3-Clause"
 }


### PR DESCRIPTION
Specifying the type and URL is [deprecated](https://docs.npmjs.com/files/package.json#license)