### PR TITLE
reference nested objects in response when pipelining

### DIFF
--- a/lib/batch.js
+++ b/lib/batch.js
@@ -132,6 +132,13 @@ internals.hasRefPart = function (parts) {
     return false;
 };
 
+internals.resolveValue = function (path, obj) {
+
+    return path.split('.').reduce(function (prev, curr) {
+
+        return prev ? prev[curr] : undefined;
+    }, obj);
+};
 
 internals.batch = function (batchRequest, resultsData, pos, parts, callback) {
 
@@ -145,7 +152,7 @@ internals.batch = function (batchRequest, resultsData, pos, parts, callback) {
             var ref = resultsData.resultsMap[parts[i].index];
 
             if (ref) {
-                var value = ref[parts[i].value];
+                var value = internals.resolveValue(parts[i].value, ref);
 
                 if (value !== null && value !== undefined) {
 

--- a/test/batch.js
+++ b/test/batch.js
@@ -437,6 +437,18 @@ describe('Batch', function () {
         });
     });
 
+    it('supports piping a nested response value from post into the next get request', function (done) {
+
+        makeRequest('{ "requests": [ {"method": "post", "path": "/echo", "payload": { "data": {"id":"44cf687663"}}}, {"method": "get", "path": "/item/$0.data.id"}] }', function (res) {
+
+            expect(res.length).to.equal(2);
+            expect(res[0].data.id).to.equal('44cf687663');
+            expect(res[1].id).to.equal('44cf687663');
+            expect(res[1].name).to.equal('Item');
+            done();
+        });
+    });
+
     it('handles null payloads gracefully', function (done) {
 
         makeRequest('{ "requests": [ {"method": "post", "path": "/echo", "payload":{"a":1}}, {"method": "post", "path": "/echo", "payload":null}] }', function (res) {
@@ -499,6 +511,15 @@ describe('Batch', function () {
     it('a non-existant reference returns an internal error', function (done) {
 
         makeRequest('{ "requests": [{"method": "get", "path": "/item"}, {"method": "get", "path": "/item/$0.nothere"}] }', function (res) {
+
+            expect(res.statusCode).to.equal(500);
+            done();
+        });
+    });
+
+    it('a non-existant & nested reference returns an internal error', function (done) {
+
+        makeRequest('{ "requests": [ {"method": "post", "path": "/echo", "payload": { "data": {"id":"44cf687663"}}}, {"method": "get", "path": "/item/$0.data.not.here"}] }', function (res) {
 
             expect(res.statusCode).to.equal(500);
             done();


### PR DESCRIPTION
This enables referencing values inside response objects when pipelining.

Includes tests.

Fixes #50 