### PR TITLE
Reference value illegal characters check is too restrictive

### DIFF
--- a/lib/batch.js
+++ b/lib/batch.js
@@ -164,7 +164,7 @@ internals.buildPath = function (resultsData, pos, parts) {
             break;
         }
 
-        if (!/^[\w:]+$/.test(value)) {
+        if (!/^[\w:-]+$/.test(value)) {
             error = new Error('Reference value includes illegal characters');
             break;
         }


### PR DESCRIPTION
My API uses UUIDs such as "7d18617c-f7b5-4e82-9eaa-beb647630d0c" and the current RegEx is too restrictive.  Allowing dashes makes my case work.
