### PR TITLE
Mitigate possible ReDoS

### DIFF
--- a/lib/batch.js
+++ b/lib/batch.js
@@ -74,7 +74,6 @@ module.exports.config = function (settings) {
                 await internals.process(request, requests, payloads, resultsData);
             }
             catch (err) {
-                // console.log("ERROR ", err);
                 throw Boom.badRequest(err);
             }
 
@@ -157,6 +156,12 @@ internals.buildPath = function (resultsData, pos, parts) {
 
         if (value === null || value === undefined) {
             error = new Error('Reference not found');
+            break;
+        }
+
+        // limit the length of reference values
+        if (value.length >= 500) {
+            error = new Error('Reference value length exceeds the maximum of 500 characters');
             break;
         }
 

--- a/test/batch.js
+++ b/test/batch.js
@@ -229,17 +229,16 @@ describe('Batch', () => {
         expect(res[1]).to.equal('Array Item 0');
     });
 
-    it('supports piping a response into the next request', async () => {
+    it('supports piping integer response into the next request', async () => {
 
-        const res = await Internals.makeRequest(server, '{ "requests": [ {"method": "get", "path": "/item"}, {"method": "get", "path": "/item/$0.id"}] }');
+        const res = await Internals.makeRequest(server, '{ "requests": [ {"method": "get", "path": "/int"}, {"method": "get", "path": "/int/$0.id"}] }');
 
         expect(res.length).to.equal(2);
-        expect(res[0].id).to.equal('55cf687663');
-        expect(res[0].name).to.equal('Active Item');
-        expect(res[1].id).to.equal('55cf687663');
-        expect(res[1].name).to.equal('Item');
+        expect(res[0].id).to.equal(123);
+        expect(res[0].name).to.equal('Integer Item');
+        expect(res[1].id).to.equal('123');
+        expect(res[1].name).to.equal('Integer');
     });
-
 
     it('supports the return of strings instead of json', async () => {
 

--- a/test/batch.js
+++ b/test/batch.js
@@ -229,14 +229,17 @@ describe('Batch', () => {
         expect(res[1]).to.equal('Array Item 0');
     });
 
-    it('Does not allow piping a response greater than 500 characters in length', async () => {
+    it('supports piping a response into the next request', async () => {
 
-        const res = await Internals.makeRequest(server, '{ "requests": [ {"method": "get", "path": "/long-id"}, {"method": "get", "path": "/int/$0.id"}] }');
+        const res = await Internals.makeRequest(server, '{ "requests": [ {"method": "get", "path": "/item"}, {"method": "get", "path": "/item/$0.id"}] }');
 
-        expect(res.statusCode).to.equal(400);
-        expect(res.error).to.equal('Bad Request');
-        expect(res.message).to.equal('Reference value length exceeds the maximum of 500 characters');
+        expect(res.length).to.equal(2);
+        expect(res[0].id).to.equal('55cf687663');
+        expect(res[0].name).to.equal('Active Item');
+        expect(res[1].id).to.equal('55cf687663');
+        expect(res[1].name).to.equal('Item');
     });
+
 
     it('supports the return of strings instead of json', async () => {
 
@@ -260,15 +263,13 @@ describe('Batch', () => {
         expect(res[1].name).to.equal('Integer');
     });
 
-    it('supports piping a response into the next request', async () => {
+    it('Does not allow piping a response greater than 500 characters in length', async () => {
 
-        const res = await Internals.makeRequest(server, '{ "requests": [ {"method": "get", "path": "/item"}, {"method": "get", "path": "/item/$0.id"}] }');
+        const res = await Internals.makeRequest(server, '{ "requests": [ {"method": "get", "path": "/long-id"}, {"method": "get", "path": "/int/$0.id"}] }');
 
-        expect(res.length).to.equal(2);
-        expect(res[0].id).to.equal('55cf687663');
-        expect(res[0].name).to.equal('Active Item');
-        expect(res[1].id).to.equal('55cf687663');
-        expect(res[1].name).to.equal('Item');
+        expect(res.statusCode).to.equal(400);
+        expect(res.error).to.equal('Bad Request');
+        expect(res.message).to.equal('Reference value length exceeds the maximum of 500 characters');
     });
 
     it('supports posting multiple requests', async () => {

--- a/test/batch.js
+++ b/test/batch.js
@@ -229,15 +229,13 @@ describe('Batch', () => {
         expect(res[1]).to.equal('Array Item 0');
     });
 
-    it('supports piping integer response into the next request', async () => {
+    it('Does not allow piping a response greater than 500 characters in length', async () => {
 
-        const res = await Internals.makeRequest(server, '{ "requests": [ {"method": "get", "path": "/int"}, {"method": "get", "path": "/int/$0.id"}] }');
+        const res = await Internals.makeRequest(server, '{ "requests": [ {"method": "get", "path": "/long-id"}, {"method": "get", "path": "/int/$0.id"}] }');
 
-        expect(res.length).to.equal(2);
-        expect(res[0].id).to.equal(123);
-        expect(res[0].name).to.equal('Integer Item');
-        expect(res[1].id).to.equal('123');
-        expect(res[1].name).to.equal('Integer');
+        expect(res.statusCode).to.equal(400);
+        expect(res.error).to.equal('Bad Request');
+        expect(res.message).to.equal('Reference value length exceeds the maximum of 500 characters');
     });
 
     it('supports the return of strings instead of json', async () => {
@@ -260,6 +258,17 @@ describe('Batch', () => {
         expect(res[0].name).to.equal('Zero Item');
         expect(res[1].id).to.equal('0');
         expect(res[1].name).to.equal('Integer');
+    });
+
+    it('supports piping a response into the next request', async () => {
+
+        const res = await Internals.makeRequest(server, '{ "requests": [ {"method": "get", "path": "/item"}, {"method": "get", "path": "/item/$0.id"}] }');
+
+        expect(res.length).to.equal(2);
+        expect(res[0].id).to.equal('55cf687663');
+        expect(res[0].name).to.equal('Active Item');
+        expect(res[1].id).to.equal('55cf687663');
+        expect(res[1].name).to.equal('Item');
     });
 
     it('supports posting multiple requests', async () => {

--- a/test/internals.js
+++ b/test/internals.js
@@ -21,6 +21,18 @@ const activeItemHandler = function (request, h) {
     });
 };
 
+const longIdHandler = function (request, h) {
+
+    // return an item with a 500 character long value
+    return h.response({
+        'id': '1111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111' +
+              '1111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111' +
+              '1111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111' +
+              '1111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111' +
+              '1111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111'
+    });
+};
+
 const itemHandler = function (request, h) {
 
     return h.response({
@@ -179,6 +191,7 @@ module.exports.setupServer = async function () {
         { method: 'PUT', path: '/echo', handler: echoHandler },
         { method: 'GET', path: '/profile', handler: profileHandler },
         { method: 'GET', path: '/item', handler: activeItemHandler },
+        { method: 'GET', path: '/long-id', handler: longIdHandler },
         { method: 'GET', path: '/deepItem', handler: deepItemHandler },
         { method: 'GET', path: '/array', handler: arrayHandler },
         { method: 'GET', path: '/item/{id}', handler: itemHandler },


### PR DESCRIPTION
The regex that checks pipelined values for valid URL characters can be exploited by pipelining extremely long responses into it. I've limited response value lengths that are pipelined into URLs to 500 characters, which should be more than enough in most cases.