### PR TITLE
Inject credentials from batch endpoint if applicable

### DIFF
--- a/lib/batch.js
+++ b/lib/batch.js
@@ -331,6 +331,7 @@ internals.dispatch = async function (batchRequest, request) {
     const injectOptions = {
         url: path,
         method: request.method,
+        credentials: batchRequest.auth.credentials,
         headers: batchRequest.headers,
         payload: body
     };

--- a/test/batch.js
+++ b/test/batch.js
@@ -9,7 +9,7 @@ const Internals = require('./internals.js');
 // Test shortcuts
 
 const lab = exports.lab = Lab.script();
-const { describe, it, before } = lab;
+const { describe, it, before, beforeEach } = lab;
 const { expect } = Code;
 
 let server = null;
@@ -19,6 +19,11 @@ describe('Batch', () => {
     before( async () => {
 
         server = await Internals.setupServer();
+    });
+
+    beforeEach( () => {
+
+        server.app = { authCount: 0 };
     });
 
     it('shows single response when making request for single endpoint', async () => {
@@ -652,5 +657,14 @@ describe('Batch', () => {
         expect(res[3]).to.equal({ id: '55cf687663', name: 'Item' });
         expect(res[4]).to.equal({ id: '55cf687663', paramString: 'Item', queryString: 'Item', payloadString: 'Item' });
         expect(res[5]).to.equal({ id: '55cf687663', name: 'John Doe' });
+    });
+
+    it('supports reusing batch endpoint credentials for subsequent requests', async () => {
+
+        const res = await Internals.makeAuthenticatedRequest(server, '{ "requests": [ {"method": "get", "path": "/protected"}, {"method": "get", "path": "/protected"} ] }');
+
+        expect(server.app.authCount).to.equal(1);
+        expect(res[0]).to.equal('authenticated');
+        expect(res[1]).to.equal('authenticated');
     });
 });


### PR DESCRIPTION
This pull request serves as an optimization for batch requests that require authentication.

**Expected Result:**
If the batch endpoint requires authentication, it should re-use those credentials for any of the subsequent injected requests. In other words, it should only check the session storage once for all the requests in a batch.

**Actual Result:**
The subsequent requests ignore the initial credential validation and performs a session lookup for the _n_ requests.

**Reproduction Steps:**
1. Apply an authentication strategy to your batch endpoint (e.g.)
```javascript
    options: {
      batchEndpoint: '/api/batch',
      tags: ['batch'],
      auth: 'session'
    }
```
2. Define an endpoint that requires the same authentication strategy (e.g.)
```javascript
  {
    method: 'POST',
    path: '/api/users',
    config: {
      auth: {
        strategy: 'session',
        scope: ['users:read']
      }
    },
    handler: UserController.createUser
  }
```
3. Make a POST request with a payload (e.g.)
```javascript
[ { method: 'POST',
    path: '/api/users',
    payload: { first_name: 'Andrew', last_name: 'Fake' } },
  { method: 'POST',
    path: '/api/users',
    payload: { first_name: 'John', last_name: 'Doe' } } ]
```
4. Observe session storage. The session lookup is linear to the number requests instead of constant.
