### PR TITLE
Fixes issue #88. Now function `internals.evalResults` in `lib/batch.js` returns `0` when `Hoek.reach(result, path)` evaluates to `0`.

### DIFF
--- a/lib/batch.js
+++ b/lib/batch.js
@@ -214,7 +214,13 @@ internals.evalResults = function (results, index, path) {
         return result;
     }
 
-    return Hoek.reach(result, path) || {};
+    const evaluatedResult = Hoek.reach(result, path);
+
+    if(!evaluatedResult && evaluatedResult !== 0) {
+      evaluatedResult = {};
+    }
+
+    return evaluatedResult;
 };
 
 internals.buildPayload = function (payload, resultsData, parts) {


### PR DESCRIPTION
The function `internals.evalResults` used to return `{}` even when `Hoek.reach(result, path)` evaluated to `0`. This was because of the line:  
  
    Hoek.reach(result, path) || {}  
  
When  `Hoek.reach(result, path)` evaluated to `0`,  the above line of code evaluated to `{}` since `0` is a `falsy` value. 

The above bug #88  has been fixed with this commit.