### PR TITLE
Fixes issue #88. Now function `internals.evalResults` in `lib/batch.js` returns `0` when `Hoek.reach(result, path)` evaluates to `0`.

### DIFF
--- a/lib/batch.js
+++ b/lib/batch.js
@@ -216,8 +216,8 @@ internals.evalResults = function (results, index, path) {
 
     const evaluatedResult = Hoek.reach(result, path);
 
-    if(!evaluatedResult && evaluatedResult !== 0) {
-      evaluatedResult = {};
+    if (!evaluatedResult && evaluatedResult !== 0) {
+        evaluatedResult = {};
     }
 
     return evaluatedResult;

--- a/lib/batch.js
+++ b/lib/batch.js
@@ -214,7 +214,13 @@ internals.evalResults = function (results, index, path) {
         return result;
     }
 
-    return Hoek.reach(result, path) || {};
+    const evaluatedResult = Hoek.reach(result, path);
+
+    if(!evaluatedResult && evaluatedResult !== 0) {
+      evaluatedResult = {};
+    }
+
+    return evaluatedResult;
 };
 
 internals.buildPayload = function (payload, resultsData, parts) {

--- a/test/batch.js
+++ b/test/batch.js
@@ -30,6 +30,13 @@ describe('Batch', () => {
         expect(res.length).to.equal(1);
     });
 
+    it('Requests in series now substitutes 0 when needed', async () => {
+        const res = await Internals.makeRequest(server, '{ "requests": [{ "method": "get", "path": "/zero" }, { "method": "post", "path": "/returnInputtedInteger", "payload": { "id": "$0.id" } }] }');
+
+        expect(res[0].id).to.equal(0);
+        expect(res[1]).to.equal(0);
+    });
+
     it('supports redirect', async () => {
 
         const res = await Internals.makeRequest(server, '{ "requests": [{ "method": "get", "path": "/redirect" }] }');

--- a/test/batch.js
+++ b/test/batch.js
@@ -30,14 +30,6 @@ describe('Batch', () => {
         expect(res.length).to.equal(1);
     });
 
-    it('Requests in series now substitutes 0 when needed', async () => {
-        
-        const res = await Internals.makeRequest(server, '{ "requests": [{ "method": "get", "path": "/zero" }, { "method": "post", "path": "/returnInputtedInteger", "payload": { "id": "$0.id" } }] }');
-
-        expect(res[0].id).to.equal(0);
-        expect(res[1]).to.equal(0);
-    });
-
     it('supports redirect', async () => {
 
         const res = await Internals.makeRequest(server, '{ "requests": [{ "method": "get", "path": "/redirect" }] }');
@@ -505,5 +497,13 @@ describe('Batch', () => {
         expect(res[0].name).to.equal('Active Item');
         expect(res[1].foo).to.be.empty();
 
+    });
+
+    it('Requests in series now substitutes 0 when needed', async () => {
+
+        const res = await Internals.makeRequest(server, '{ "requests": [{ "method": "get", "path": "/zero" }, { "method": "post", "path": "/returnInputtedInteger", "payload": { "id": "$0.id" } }] }');
+
+        expect(res[0].id).to.equal(0);
+        expect(res[1]).to.equal(0);
     });
 });

--- a/test/batch.js
+++ b/test/batch.js
@@ -31,6 +31,7 @@ describe('Batch', () => {
     });
 
     it('Requests in series now substitutes 0 when needed', async () => {
+        
         const res = await Internals.makeRequest(server, '{ "requests": [{ "method": "get", "path": "/zero" }, { "method": "post", "path": "/returnInputtedInteger", "payload": { "id": "$0.id" } }] }');
 
         expect(res[0].id).to.equal(0);

--- a/test/internals.js
+++ b/test/internals.js
@@ -171,6 +171,11 @@ const echoHandler = function (request, h) {
     return request.payload;
 };
 
+const returnInputtedIntegerHandler = function (request, h) {
+
+    return request.payload.id;
+}
+
 module.exports.setupServer = async function () {
 
     const server = new Hapi.Server();
@@ -205,7 +210,8 @@ module.exports.setupServer = async function () {
                 ]
             }
         },
-        { method: 'GET', path: '/redirect', handler: redirectHandler }
+        { method: 'GET', path: '/redirect', handler: redirectHandler },
+        { method: 'POST', path: '/returnInputtedInteger', handler: returnInputtedIntegerHandler }
     ]);
 
     await server.register(Bassmaster);

--- a/test/internals.js
+++ b/test/internals.js
@@ -174,7 +174,7 @@ const echoHandler = function (request, h) {
 const returnInputtedIntegerHandler = function (request, h) {
 
     return request.payload.id;
-}
+};
 
 module.exports.setupServer = async function () {
 


### PR DESCRIPTION
The function internals.evalResults used to return {} even when Hoek.reach(result, path) evaluated to 0. This was because of the line:  


    Hoek.reach(result, path) || {}  
  

When Hoek.reach(result, path) evaluated to 0, the above line of code evaluated to {} since 0 is a falsy value.

Also added test case to verify the same.

The above bug #88  has been fixed with this commit.