### PR TITLE
Bug fix #88 - The function `internals.evalResults` in `lib/batch.js` now returns 0 when `Hoek.reach` evaluates to `0` instead of `{}`.

### DIFF
--- a/lib/batch.js
+++ b/lib/batch.js
@@ -216,7 +216,7 @@ internals.evalResults = function (results, index, path) {
 
     const evalResults = Hoek.reach(result, path);
 
-    return evalResults || evalResults === 0 ? evalResults : {};
+    return evalResults || evalResults === 0 || evalResults === false ? evalResults : {};
 };
 
 internals.buildPayload = function (payload, resultsData, parts) {

--- a/lib/batch.js
+++ b/lib/batch.js
@@ -216,7 +216,7 @@ internals.evalResults = function (results, index, path) {
 
     const evalResults = Hoek.reach(result, path);
 
-    return evalResults || evalResults === 0 || evalResults === false ? evalResults : {};
+    return evalResults || evalResults === 0 || evalResults === false || evalResults === '' || evalResults === null ? evalResults : {};
 };
 
 internals.buildPayload = function (payload, resultsData, parts) {

--- a/lib/batch.js
+++ b/lib/batch.js
@@ -216,7 +216,7 @@ internals.evalResults = function (results, index, path) {
 
     const evalResults = Hoek.reach(result, path);
 
-    return evalResults || evalResults === 0 || evalResults === false || evalResults === '' || evalResults === null ? evalResults : {};
+    return evalResults || evalResults === 0 || evalResults === false ? evalResults : {};
 };
 
 internals.buildPayload = function (payload, resultsData, parts) {

--- a/lib/batch.js
+++ b/lib/batch.js
@@ -216,11 +216,7 @@ internals.evalResults = function (results, index, path) {
 
     const evalResults = Hoek.reach(result, path);
 
-    if (evalResults || evalResults === 0) {
-        return evalResults;
-    }
-
-    return {};
+    return evalResults || evalResults === 0 ? evalResults : {};
 };
 
 internals.buildPayload = function (payload, resultsData, parts) {

--- a/lib/batch.js
+++ b/lib/batch.js
@@ -214,7 +214,13 @@ internals.evalResults = function (results, index, path) {
         return result;
     }
 
-    return Hoek.reach(result, path) || {};
+    const evalResults = Hoek.reach(result, path);
+
+    if (evalResults || evalResults === 0) {
+        return evalResults;
+    }
+
+    return {};
 };
 
 internals.buildPayload = function (payload, resultsData, parts) {

--- a/test/batch.js
+++ b/test/batch.js
@@ -514,20 +514,4 @@ describe('Batch', () => {
         expect(res[0]).to.equal(false);
         expect(res[1]).to.equal(false);
     });
-
-    it('Now substitutes even `\'\'` in serialized requests', async () => {
-
-        const res = await Internals.makeRequest(server, '{ "requests": [ {"method": "get", "path": "/getEmptyString"}, {"method": "post", "path": "/returnInputtedString", "payload": {"str": "$0"}} ] }');
-
-        expect(res[0]).to.equal('');
-        expect(res[1]).to.equal('');
-    });
-
-    it('Now substitutes even `null` in serialized requests', async () => {
-
-        const res = await Internals.makeRequest(server, '{ "requests": [ {"method": "get", "path": "/getNull"}, {"method": "post", "path": "/returnInputtedNull", "payload": {"val": "$0"}} ] }');
-
-        expect(res[0]).to.equal(null);
-        expect(res[1]).to.equal(null);
-    });
 });

--- a/test/batch.js
+++ b/test/batch.js
@@ -499,7 +499,7 @@ describe('Batch', () => {
 
     });
 
-    it('Now substitutes even 0 in serialized requests', async () => {
+    it('Now substitutes even `0` in serialized requests', async () => {
 
         const res = await Internals.makeRequest(server, '{ "requests": [ {"method": "get", "path": "/zero"}, {"method": "post", "path": "/returnInputtedInteger", "payload": {"id": "$0.id"}} ] }');
 
@@ -507,11 +507,27 @@ describe('Batch', () => {
         expect(res[1]).to.equal(0);
     });
 
-    it('Now substitutes even "false" in serialized requests', async () => {
+    it('Now substitutes even `false` in serialized requests', async () => {
 
         const res = await Internals.makeRequest(server, '{ "requests": [ {"method": "get", "path": "/getFalse"}, {"method": "post", "path": "/returnInputtedBoolean", "payload": {"bool": "$0"}} ] }');
 
         expect(res[0]).to.equal(false);
         expect(res[1]).to.equal(false);
+    });
+
+    it('Now substitutes even `\'\'` in serialized requests', async () => {
+
+        const res = await Internals.makeRequest(server, '{ "requests": [ {"method": "get", "path": "/getEmptyString"}, {"method": "post", "path": "/returnInputtedString", "payload": {"str": "$0"}} ] }');
+
+        expect(res[0]).to.equal('');
+        expect(res[1]).to.equal('');
+    });
+
+    it('Now substitutes even `null` in serialized requests', async () => {
+
+        const res = await Internals.makeRequest(server, '{ "requests": [ {"method": "get", "path": "/getNull"}, {"method": "post", "path": "/returnInputtedNull", "payload": {"val": "$0"}} ] }');
+
+        expect(res[0]).to.equal(null);
+        expect(res[1]).to.equal(null);
     });
 });

--- a/test/batch.js
+++ b/test/batch.js
@@ -506,4 +506,12 @@ describe('Batch', () => {
         expect(res[0].id).to.equal(0);
         expect(res[1]).to.equal(0);
     });
+
+    it('Now substitutes even "false" in serialized requests', async () => {
+
+        const res = await Internals.makeRequest(server, '{ "requests": [ {"method": "get", "path": "/getFalse"}, {"method": "post", "path": "/returnInputtedBoolean", "payload": {"bool": "$0"}} ] }');
+
+        expect(res[0]).to.equal(false);
+        expect(res[1]).to.equal(false);
+    });
 });

--- a/test/batch.js
+++ b/test/batch.js
@@ -498,4 +498,12 @@ describe('Batch', () => {
         expect(res[1].foo).to.be.empty();
 
     });
+
+    it('Now substitutes even 0 in serialized requests', async () => {
+
+        const res = await Internals.makeRequest(server, '{ "requests": [ {"method": "get", "path": "/zero"}, {"method": "post", "path": "/returnInputtedInteger", "payload": {"id": "$0.id"}} ] }');
+
+        expect(res[0].id).to.equal(0);
+        expect(res[1]).to.equal(0);
+    });
 });

--- a/test/internals.js
+++ b/test/internals.js
@@ -171,6 +171,11 @@ const echoHandler = function (request, h) {
     return request.payload;
 };
 
+const returnInputtedIntegerHandler = function (request, h) {
+
+    return request.payload.id;
+};
+
 module.exports.setupServer = async function () {
 
     const server = new Hapi.Server();
@@ -205,7 +210,8 @@ module.exports.setupServer = async function () {
                 ]
             }
         },
-        { method: 'GET', path: '/redirect', handler: redirectHandler }
+        { method: 'GET', path: '/redirect', handler: redirectHandler },
+        { method: 'POST', path: '/returnInputtedInteger', handler: returnInputtedIntegerHandler }
     ]);
 
     await server.register(Bassmaster);

--- a/test/internals.js
+++ b/test/internals.js
@@ -186,6 +186,26 @@ const returnInputtedBooleanHandler = function (request, h) {
     return request.payload.bool;
 };
 
+const getEmptyStringHandler = function (request, h) {
+
+    return '';
+};
+
+const returnInputtedStringHandler = function (request, h) {
+
+    return request.payload.str;
+};
+
+const getNullHandler = function (request, h) {
+
+    return null;
+};
+
+const returnInputtedNullHandler = function (request, h) {
+
+    return request.payload.val;
+};
+
 module.exports.setupServer = async function () {
 
     const server = new Hapi.Server();
@@ -223,7 +243,11 @@ module.exports.setupServer = async function () {
         { method: 'GET', path: '/redirect', handler: redirectHandler },
         { method: 'POST', path: '/returnInputtedInteger', handler: returnInputtedIntegerHandler },
         { method: 'GET', path: '/getFalse', handler: getFalseHandler },
-        { method: 'POST', path: '/returnInputtedBoolean', handler: returnInputtedBooleanHandler }
+        { method: 'POST', path: '/returnInputtedBoolean', handler: returnInputtedBooleanHandler },
+        { method: 'GET', path: '/getEmptyString', handler: getEmptyStringHandler },
+        { method: 'POST', path: '/returnInputtedString', handler: returnInputtedStringHandler },
+        { method: 'GET', path: '/getNull', handler: getNullHandler },
+        { method: 'POST', path: '/returnInputtedNull', handler: returnInputtedNullHandler }
     ]);
 
     await server.register(Bassmaster);

--- a/test/internals.js
+++ b/test/internals.js
@@ -176,6 +176,16 @@ const returnInputtedIntegerHandler = function (request, h) {
     return request.payload.id;
 };
 
+const getFalseHandler = function (request, h) {
+
+    return false;
+};
+
+const returnInputtedBooleanHandler = function (request, h) {
+
+    return request.payload.bool;
+};
+
 module.exports.setupServer = async function () {
 
     const server = new Hapi.Server();
@@ -211,7 +221,9 @@ module.exports.setupServer = async function () {
             }
         },
         { method: 'GET', path: '/redirect', handler: redirectHandler },
-        { method: 'POST', path: '/returnInputtedInteger', handler: returnInputtedIntegerHandler }
+        { method: 'POST', path: '/returnInputtedInteger', handler: returnInputtedIntegerHandler },
+        { method: 'GET', path: '/getFalse', handler: getFalseHandler },
+        { method: 'POST', path: '/returnInputtedBoolean', handler: returnInputtedBooleanHandler }
     ]);
 
     await server.register(Bassmaster);

--- a/test/internals.js
+++ b/test/internals.js
@@ -186,26 +186,6 @@ const returnInputtedBooleanHandler = function (request, h) {
     return request.payload.bool;
 };
 
-const getEmptyStringHandler = function (request, h) {
-
-    return '';
-};
-
-const returnInputtedStringHandler = function (request, h) {
-
-    return request.payload.str;
-};
-
-const getNullHandler = function (request, h) {
-
-    return null;
-};
-
-const returnInputtedNullHandler = function (request, h) {
-
-    return request.payload.val;
-};
-
 module.exports.setupServer = async function () {
 
     const server = new Hapi.Server();
@@ -243,11 +223,7 @@ module.exports.setupServer = async function () {
         { method: 'GET', path: '/redirect', handler: redirectHandler },
         { method: 'POST', path: '/returnInputtedInteger', handler: returnInputtedIntegerHandler },
         { method: 'GET', path: '/getFalse', handler: getFalseHandler },
-        { method: 'POST', path: '/returnInputtedBoolean', handler: returnInputtedBooleanHandler },
-        { method: 'GET', path: '/getEmptyString', handler: getEmptyStringHandler },
-        { method: 'POST', path: '/returnInputtedString', handler: returnInputtedStringHandler },
-        { method: 'GET', path: '/getNull', handler: getNullHandler },
-        { method: 'POST', path: '/returnInputtedNull', handler: returnInputtedNullHandler }
+        { method: 'POST', path: '/returnInputtedBoolean', handler: returnInputtedBooleanHandler }
     ]);
 
     await server.register(Bassmaster);


### PR DESCRIPTION
The function `internals.evalResults` in `lib/batch.js` returned `{}` even when  
  
    Hoek.reach(result, path)  
  
evaluated to `0`. Since `0` is a `falsy` value, the line:  
  
    Hoek.reach(result, path) || {}  
  
always evaluated to `{}`.  
  
This fixes the above mentioned bug number #88 . And also a test case is added to confirm the same.
