### PR TITLE
Adds a feature where even request with  GET query strings having dependent values can be pipelined

### DIFF
--- a/lib/batch.js
+++ b/lib/batch.js
@@ -24,6 +24,7 @@ module.exports.config = function (settings) {
 
             const requests = [];
             const payloads = [];
+            const queries = [];
             const resultsData = {
                 results: [],
                 resultsMap: []
@@ -60,8 +61,10 @@ module.exports.config = function (settings) {
                     return false;
                 }
 
+                const queryParts = internals.parsePayload(req.query);
                 const payloadParts = internals.parsePayload(req.payload);
 
+                queries.push(queryParts || []);
                 payloads.push(payloadParts || []);
                 return true;
             });
@@ -71,7 +74,7 @@ module.exports.config = function (settings) {
             }
 
             try {
-                await internals.process(request, requests, payloads, resultsData);
+                await internals.process(request, requests, payloads, queries, resultsData);
             }
             catch (err) {
                 // console.log("ERROR ", err);
@@ -97,7 +100,7 @@ module.exports.config = function (settings) {
     };
 };
 
-internals.process = async function (request, requests, payloads, resultsData) {
+internals.process = async function (request, requests, payloads, queries, resultsData) {
 
     const fnsParallel = [];
     const fnsSerial = [];
@@ -105,9 +108,10 @@ internals.process = async function (request, requests, payloads, resultsData) {
     requests.forEach((requestParts, idx) => {
 
         const payloadParts = payloads[idx];
-        if (internals.hasRefPart(requestParts) || payloadParts.length) {
+        const queryParts = queries[idx];
+        if (internals.hasRefPart(requestParts) || payloadParts.length || queryParts.length) {
             return fnsSerial.push(
-                async () => await internals.batch(request, resultsData, idx, requestParts, payloadParts)
+                async () => await internals.batch(request, resultsData, idx, requestParts, payloadParts, queryParts)
             );
         }
 
@@ -240,7 +244,7 @@ internals.buildPayload = function (payload, resultsData, parts) {
     return payload;
 };
 
-internals.batch = async function (batchRequest, resultsData, pos, requestParts, payloadParts) {
+internals.batch = async function (batchRequest, resultsData, pos, requestParts, payloadParts, queryParts) {
 
     const path = internals.buildPath(resultsData, pos, requestParts);
 
@@ -261,6 +265,16 @@ internals.batch = async function (batchRequest, resultsData, pos, requestParts, 
             request.payload,
             resultsData,
             payloadParts
+        );
+    }
+
+    if (queryParts && queryParts.length) {
+
+        // Make queryParts
+        request.query = internals.buildPayload(
+            request.query,
+            resultsData,
+            queryParts
         );
     }
 

--- a/lib/batch.js
+++ b/lib/batch.js
@@ -23,8 +23,10 @@ module.exports.config = function (settings) {
         handler: async function (request, h) {
 
             const requests = [];
-            const payloads = [];
-            const queries = [];
+            const parsables = {
+                payloads: [],
+                queries: []
+            };
             const resultsData = {
                 results: [],
                 resultsMap: []
@@ -61,11 +63,11 @@ module.exports.config = function (settings) {
                     return false;
                 }
 
-                const queryParts = internals.parsePayload(req.query);
-                const payloadParts = internals.parsePayload(req.payload);
+                const queryParts = internals.parse(req.query);
+                const payloadParts = internals.parse(req.payload);
 
-                queries.push(queryParts || []);
-                payloads.push(payloadParts || []);
+                parsables.queries.push(queryParts || []);
+                parsables.payloads.push(payloadParts || []);
                 return true;
             });
 
@@ -74,7 +76,7 @@ module.exports.config = function (settings) {
             }
 
             try {
-                await internals.process(request, requests, payloads, queries, resultsData);
+                await internals.process(request, requests, parsables, resultsData);
             }
             catch (err) {
                 // console.log("ERROR ", err);
@@ -100,18 +102,22 @@ module.exports.config = function (settings) {
     };
 };
 
-internals.process = async function (request, requests, payloads, queries, resultsData) {
+internals.process = async function (request, requests, parsables, resultsData) {
 
     const fnsParallel = [];
     const fnsSerial = [];
 
     requests.forEach((requestParts, idx) => {
 
-        const payloadParts = payloads[idx];
-        const queryParts = queries[idx];
-        if (internals.hasRefPart(requestParts) || payloadParts.length || queryParts.length) {
+        const parsableParts = {
+            payloadParts: parsables.payloads[idx],
+            queryParts: parsables.queries[idx]
+        };
+        if (internals.hasRefPart(requestParts)
+        || parsableParts.payloadParts.length
+        || parsableParts.queryParts.length) {
             return fnsSerial.push(
-                async () => await internals.batch(request, resultsData, idx, requestParts, payloadParts, queryParts)
+                async () => await internals.batch(request, resultsData, idx, requestParts, parsableParts)
             );
         }
 
@@ -176,13 +182,13 @@ internals.buildPath = function (resultsData, pos, parts) {
     return error ? error : path;
 };
 
-internals.payloadRegex = /^\$(\d+)(?:\.([^\s\$]*))?/;
+internals.pipelinableParsableRegex = /^\$(\d+)(?:\.([^\s\$]*))?/;
 
 internals.requestRegex = /(?:\/)(?:\$(\d+))?(\.)?([^\/\$]*)/g;
 
-internals.parsePayload = function (obj) {
+internals.parse = function (obj) {
 
-    const payloadParts = [];
+    const parsableParts = [];
 
     if (!obj) {
         return null;
@@ -194,20 +200,20 @@ internals.parsePayload = function (obj) {
             return;
         }
 
-        const match = internals.payloadRegex.exec(value);
+        const match = internals.pipelinableParsableRegex.exec(value);
 
         if (!match) {
             return;
         }
 
-        payloadParts.push({
+        parsableParts.push({
             path: this.path,
             resultIndex: match[1],
             resultPath: match[2]
         });
     });
 
-    return payloadParts;
+    return parsableParts;
 };
 
 internals.evalResults = function (results, index, path) {
@@ -223,7 +229,7 @@ internals.evalResults = function (results, index, path) {
     return evalResults || evalResults === 0 || evalResults === false ? evalResults : {};
 };
 
-internals.buildPayload = function (payload, resultsData, parts) {
+internals.buildParsable = function (parsable, resultsData, parts) {
 
     const partsLength = parts.length;
     let result;
@@ -234,17 +240,17 @@ internals.buildPayload = function (payload, resultsData, parts) {
         result = internals.evalResults(resultsData.resultsMap, part.resultIndex, part.resultPath);
 
         if (!part.path.length) {
-            payload = result;
+            parsable = result;
         }
         else {
-            Traverse(payload).set(part.path, result);
+            Traverse(parsable).set(part.path, result);
         }
     }
 
-    return payload;
+    return parsable;
 };
 
-internals.batch = async function (batchRequest, resultsData, pos, requestParts, payloadParts, queryParts) {
+internals.batch = async function (batchRequest, resultsData, pos, requestParts, parsableParts = {}) {
 
     const path = internals.buildPath(resultsData, pos, requestParts);
 
@@ -258,23 +264,23 @@ internals.batch = async function (batchRequest, resultsData, pos, requestParts, 
 
     request.path = path;
 
-    if (payloadParts && payloadParts.length) {
+    if (parsableParts.payloadParts && parsableParts.payloadParts.length) {
 
         // Make payload
-        request.payload = internals.buildPayload(
+        request.payload = internals.buildParsable(
             request.payload,
             resultsData,
-            payloadParts
+            parsableParts.payloadParts
         );
     }
 
-    if (queryParts && queryParts.length) {
+    if (parsableParts.queryParts && parsableParts.queryParts.length) {
 
         // Make queryParts
-        request.query = internals.buildPayload(
+        request.query = internals.buildParsable(
             request.query,
             resultsData,
-            queryParts
+            parsableParts.queryParts
         );
     }
 

--- a/test/batch.js
+++ b/test/batch.js
@@ -627,10 +627,20 @@ describe('Batch', () => {
                     }
                 },
                 {
+                    method: 'POST',
+                    path: '/returnInputtedString/$3.id/$3.name',
+                    query: {
+                        queryString: '$3.name'
+                    },
+                    payload: {
+                        payloadString: '$3.name'
+                    }
+                },
+                {
                     method: 'GET',
                     path: '/profile',
                     query: {
-                        id: '$3.id'
+                        id: '$4.id'
                     }
                 }
             ]
@@ -640,6 +650,7 @@ describe('Batch', () => {
         expect(res[1]).to.equal({ id: '55cf687663', name: 'John Doe' });
         expect(res[2]).to.equal({ id: '55cf687663', name: 'Item' });
         expect(res[3]).to.equal({ id: '55cf687663', name: 'Item' });
-        expect(res[4]).to.equal({ id: '55cf687663', name: 'John Doe' });
+        expect(res[4]).to.equal({ id: '55cf687663', paramString: 'Item', queryString: 'Item', payloadString: 'Item' });
+        expect(res[5]).to.equal({ id: '55cf687663', name: 'John Doe' });
     });
 });

--- a/test/batch.js
+++ b/test/batch.js
@@ -598,4 +598,48 @@ describe('Batch', () => {
         expect(res[0]).to.equal(10041995);
         expect(res[1]).to.equal(10041995);
     });
+
+    it('Query parameters and payload both now supports pipelined requests', async () => {
+
+        const res = await Internals.makeRequest(server, JSON.stringify({
+            requests: [
+                {
+                    method: 'GET',
+                    path: '/item'
+                },
+                {
+                    method: 'GET',
+                    path: '/profile',
+                    query: {
+                        id: '$0.id'
+                    }
+                },
+                {
+                    method: 'GET',
+                    path: '/item/$1.id'
+                },
+                {
+                    method: 'POST',
+                    path: '/echo',
+                    payload: {
+                        id: '$2.id',
+                        name: '$2.name'
+                    }
+                },
+                {
+                    method: 'GET',
+                    path: '/profile',
+                    query: {
+                        id: '$3.id'
+                    }
+                }
+            ]
+        }));
+
+        expect(res[0]).to.equal({ id: '55cf687663', name: 'Active Item' });
+        expect(res[1]).to.equal({ id: '55cf687663', name: 'John Doe' });
+        expect(res[2]).to.equal({ id: '55cf687663', name: 'Item' });
+        expect(res[3]).to.equal({ id: '55cf687663', name: 'Item' });
+        expect(res[4]).to.equal({ id: '55cf687663', name: 'John Doe' });
+    });
 });

--- a/test/internals.js
+++ b/test/internals.js
@@ -191,6 +191,16 @@ const returnPathParamHandler = function (request, h) {
     return request.params.pathParamInteger;
 };
 
+const returnInputtedStringHandler = function (request, h) {
+
+    return {
+        id: request.params.id,
+        paramString: request.params.paramString,
+        queryString: request.query.queryString,
+        payloadString: request.payload.payloadString
+    };
+};
+
 module.exports.setupServer = async function () {
 
     const server = new Hapi.Server();
@@ -229,7 +239,8 @@ module.exports.setupServer = async function () {
         { method: 'POST', path: '/returnInputtedInteger', handler: returnInputtedIntegerHandler },
         { method: 'GET', path: '/returnPathParamInteger/{pathParamInteger}', handler: returnPathParamHandler },
         { method: 'GET', path: '/getFalse', handler: getFalseHandler },
-        { method: 'POST', path: '/returnInputtedBoolean', handler: returnInputtedBooleanHandler }
+        { method: 'POST', path: '/returnInputtedBoolean', handler: returnInputtedBooleanHandler },
+        { method: 'POST', path: '/returnInputtedString/{id}/{paramString}', handler: returnInputtedStringHandler }
     ]);
 
     await server.register(Bassmaster);


### PR DESCRIPTION
Closes #95 

Now when the requests are:  
  
```
{
    "requests": [
        {
             "method": "GET",
             "path": "/get/product?product_id=564"
        },
        {
             "method": "GET",
             "path": "/get/manufacturer",
             "query": {
                 "manufacturter_id": "$0.manufacturer_id"
             }
        }
    ]
}
```  
  
inspite of being a query parameter(and not a path parameter), `$0.manufacturer_id` will now be parsed. 

Hence, even pipe lined query parameters will now be parsed if dependent on previous requests.