### PR TITLE
Fixed Bug where in a pipelined request, if the response of n'th request is needed by any other request where n > 9, i.e. a single digit number, it will work as expected.

### DIFF
--- a/lib/batch.js
+++ b/lib/batch.js
@@ -174,7 +174,7 @@ internals.buildPath = function (resultsData, pos, parts) {
 
 internals.payloadRegex = /^\$(\d+)(?:\.([^\s\$]*))?/;
 
-internals.requestRegex = /(?:\/)(?:\$(\d)+\.)?([^\/\$]*)/g;
+internals.requestRegex = /(?:\/)(?:\$(\d+)\.)?([^\/\$]*)/g;
 
 internals.parsePayload = function (obj) {
 

--- a/test/batch.js
+++ b/test/batch.js
@@ -514,4 +514,66 @@ describe('Batch', () => {
         expect(res[0]).to.equal(false);
         expect(res[1]).to.equal(false);
     });
+
+    it('Checks if pipeline requests works for a request depending on other request with index in non-single digit', async () => {
+
+        const res = await Internals.makeRequest(server, JSON.stringify({
+            requests: [
+                {
+                    method: 'GET',
+                    path: '/item/0'
+                },
+                {
+                    method: 'GET',
+                    path: '/item/1'
+                },
+                {
+                    method: 'GET',
+                    path: '/item/2'
+                },
+                {
+                    method: 'GET',
+                    path: '/item/3'
+                },
+                {
+                    method: 'GET',
+                    path: '/item/4'
+                },
+                {
+                    method: 'GET',
+                    path: '/item/5'
+                },
+                {
+                    method: 'GET',
+                    path: '/item/6'
+                },
+                {
+                    method: 'GET',
+                    path: '/item/7'
+                },
+                {
+                    method: 'GET',
+                    path: '/item/8'
+                },
+                {
+                    method: 'GET',
+                    path: '/item/9'
+                },
+                {
+                    method: 'GET',
+                    path: '/item/10'
+                },
+                {
+                    method: 'GET',
+                    path: '/item/$10.id'
+                }
+            ]
+        }));
+
+        expect(res[0].id).to.equal('0');
+        expect(res[1].id).to.equal('1');
+        expect(res[10].id).to.equal('10');
+        expect(res[11].id).to.equal('10');
+        expect(res[11].name).to.equal('Item');
+    });
 });


### PR DESCRIPTION
Closes #97 

The problem was in `internals.requestRegex`.  
  
Where the regex was:  
  
    /(?:\/)(?:\$(\d)+\.)?([^\/\$]*)/g  
  
I changed it to:  
  
    /(?:\/)(?:\$(\d+)\.)?([^\/\$]*)/g  
  
So in the previous buggy regex, `\d` was in 1 capturing regex group as the `+` was outside that group.    
So I put `\d+` in the same capturing group.  
  
I also created a test case for the same. All test cases are working.