### PR TITLE
Fixes bug where #99, where in path parameters of pipelined requests, `$n` doesn't necessarily have to have a reachable path. This is helpful in cases when the response of a request on which the current request is dependent on, doesn't return a JSON object but just empty strings

### DIFF
--- a/lib/batch.js
+++ b/lib/batch.js
@@ -34,15 +34,15 @@ module.exports.config = function (settings) {
             request.payload.requests.every((req, idx) => {
 
                 const requestParts = [];
-                const result = req.path.replace(internals.requestRegex, (match, p1, p2) => {
+                const result = req.path.replace(internals.requestRegex, (match, p1, p2, p3) => {
 
                     if (!p1) {
-                        requestParts.push({ type: 'text', value: p2 });
+                        requestParts.push({ type: 'text', value: p3 });
                         return '';
                     }
 
                     if (p1 < idx) {
-                        requestParts.push({ type: 'ref', index: p1, value: p2 });
+                        requestParts.push({ type: 'ref', index: p1, value: p3 });
                         return '';
                     }
 
@@ -153,7 +153,7 @@ internals.buildPath = function (resultsData, pos, parts) {
             break;
         }
 
-        value = Hoek.reach(ref, part.value);
+        value = part.value ? Hoek.reach(ref, part.value) : ref;
 
         if (value === null || value === undefined) {
             error = new Error('Reference not found');
@@ -174,7 +174,7 @@ internals.buildPath = function (resultsData, pos, parts) {
 
 internals.payloadRegex = /^\$(\d+)(?:\.([^\s\$]*))?/;
 
-internals.requestRegex = /(?:\/)(?:\$(\d+)\.)?([^\/\$]*)/g;
+internals.requestRegex = /(?:\/)(?:\$(\d+))?(\.)?([^\/\$]*)/g;
 
 internals.parsePayload = function (obj) {
 

--- a/test/batch.js
+++ b/test/batch.js
@@ -576,4 +576,26 @@ describe('Batch', () => {
         expect(res[11].id).to.equal('10');
         expect(res[11].name).to.equal('Item');
     });
+
+    it('substitutes index in url without any resultPath in url path parameters', async () => {
+
+        const res = await Internals.makeRequest(server, JSON.stringify({
+            requests: [
+                {
+                    method: 'POST',
+                    path: '/returnInputtedInteger',
+                    payload: {
+                        id: 10041995
+                    }
+                },
+                {
+                    method: 'GET',
+                    path: '/returnPathParamInteger/$0'
+                }
+            ]
+        }));
+
+        expect(res[0]).to.equal(10041995);
+        expect(res[1]).to.equal(10041995);
+    });
 });

--- a/test/internals.js
+++ b/test/internals.js
@@ -186,6 +186,11 @@ const returnInputtedBooleanHandler = function (request, h) {
     return request.payload.bool;
 };
 
+const returnPathParamHandler = function (request, h) {
+
+    return request.params.pathParamInteger;
+};
+
 module.exports.setupServer = async function () {
 
     const server = new Hapi.Server();
@@ -222,6 +227,7 @@ module.exports.setupServer = async function () {
         },
         { method: 'GET', path: '/redirect', handler: redirectHandler },
         { method: 'POST', path: '/returnInputtedInteger', handler: returnInputtedIntegerHandler },
+        { method: 'GET', path: '/returnPathParamInteger/{pathParamInteger}', handler: returnPathParamHandler },
         { method: 'GET', path: '/getFalse', handler: getFalseHandler },
         { method: 'POST', path: '/returnInputtedBoolean', handler: returnInputtedBooleanHandler }
     ]);


### PR DESCRIPTION
Closes #99 

Modified the `internals.requestRegex`.  
  
Now it also matches for a path parameter without any reachable content.  
  
That is, if the payload is:  
  

```
"requests": [
    { 
        "method": "get",
        "path": "/some/path"
    },
    {
        "method": "get",
        "path": "/another/path/$0"
    }
]
```  
  
And if the `0th` request returns just a string, say, `someString`,  
  
The `path` in the `1st` request is taken as `/another/path/someString`  
  
Now the regex has 4 groups:  
  
For example, the URL path is: `/some/path/$1.name.firstname/$1.id/$0/something`, the matches from (regex101[regex101.com]) is:  
    
```
Full match: `/some`
p1: N/A
p2: N/A
p3: "some"
  
Full match: `/path`
p1: N/A
p2: N/A
p3: "path"
  
Full match: "/$1.name.firstname"
p1: "1"
p2: "."
p3: "name.firstname"
  
Full match: "/$1.id"
p1: "1"
p2: "."
p3: "id"     
  
Full match: "/$0"
p1: "0"
p2: N/A
p3: ""    
  
Full match: `/something`
p1: N/A
p2: N/A
p3: "something"
```
